### PR TITLE
Point app and docs at the public production domain

### DIFF
--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -8,7 +8,7 @@
       "developmentClient": true,
       "distribution": "internal",
       "env": {
-        "EXPO_PUBLIC_API_URL": "https://test-kyl3kan3-6147s-projects.vercel.app",
+        "EXPO_PUBLIC_API_URL": "https://test-six-rho-qcpw39t96j.vercel.app",
         "EXPO_PUBLIC_RC_IOS_KEY": "appl_oSKaoyDuFqfnclBljpKDcaZQKlQ",
         "EXPO_PUBLIC_RC_ANDROID_KEY": "goog_IHBjRzSWYDxkLCzvTNhjGTZXtTp"
       }
@@ -16,7 +16,7 @@
     "preview": {
       "distribution": "internal",
       "env": {
-        "EXPO_PUBLIC_API_URL": "https://test-kyl3kan3-6147s-projects.vercel.app",
+        "EXPO_PUBLIC_API_URL": "https://test-six-rho-qcpw39t96j.vercel.app",
         "EXPO_PUBLIC_RC_IOS_KEY": "appl_oSKaoyDuFqfnclBljpKDcaZQKlQ",
         "EXPO_PUBLIC_RC_ANDROID_KEY": "goog_IHBjRzSWYDxkLCzvTNhjGTZXtTp"
       }
@@ -24,7 +24,7 @@
     "production": {
       "autoIncrement": true,
       "env": {
-        "EXPO_PUBLIC_API_URL": "https://test-kyl3kan3-6147s-projects.vercel.app",
+        "EXPO_PUBLIC_API_URL": "https://test-six-rho-qcpw39t96j.vercel.app",
         "EXPO_PUBLIC_RC_IOS_KEY": "appl_oSKaoyDuFqfnclBljpKDcaZQKlQ",
         "EXPO_PUBLIC_RC_ANDROID_KEY": "goog_IHBjRzSWYDxkLCzvTNhjGTZXtTp"
       }

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -9,7 +9,7 @@ Everything the code needs to run, and where each key goes.
 | **Neon project (production)** | `ADHDApp` (id `cool-rain-75506757`, Vercel-managed org, aws-us-east-1) — attached to the Vercel project via the Neon integration; `DATABASE_URL` is auto-injected into Vercel |
 | Neon branches | `main` (production) + `test` (`br-summer-frost-ah5hocrh`, integration tests / e2e) |
 | Schema | Applied via `drizzle-kit migrate` (`apps/api/drizzle/`); all 31 API tests green against the test branch |
-| Vercel project | `test` (`prj_hQ217OFrNusWcmOwsuD3XSYWEzcq`), git-integrated with `kyl3kan3/Test`; production domain `https://test-kyl3kan3-6147s-projects.vercel.app` (deploys `main`; PR branches get preview deployments) |
+| Vercel project | `test` (`prj_hQ217OFrNusWcmOwsuD3XSYWEzcq`), git-integrated with `kyl3kan3/Test`; production domain `https://test-six-rho-qcpw39t96j.vercel.app` (deploys `main`; PR branches get preview deployments) |
 | (deprecated) Neon project `dothething` | `quiet-glitter-59483542` — superseded by ADHDApp; safe to delete in the Neon console |
 | RevenueCat project | `DoTheThing` (project id `proj53d6a450`) |
 | RC apps | iOS `app19619b61bf` (bundle `app.dothething.mobile`), Android `appe726220701` |
@@ -73,7 +73,7 @@ GitHub Actions secret: `DATABASE_URL_TEST` (used by API tests + e2e).
       Consider removing the close (X) button — this is a hard paywall (the app
       gates on entitlement either way, but no-X converts better).
    3. Add the **webhook**: URL
-      `https://test-kyl3kan3-6147s-projects.vercel.app/api/webhooks/revenuecat`,
+      `https://test-six-rho-qcpw39t96j.vercel.app/api/webhooks/revenuecat`,
       auth header = the `REVENUECAT_WEBHOOK_AUTH` value (already set in Vercel
       env — copy it from the Vercel dashboard). Also paste the RC **secret API
       key** into Vercel as `REVENUECAT_SECRET_KEY`.


### PR DESCRIPTION
Post-merge fast-follow: production smoke-testing revealed the team-scoped `test-kyl3kan3-6147s-projects.vercel.app` domain sits behind Vercel SSO (302 for API clients). The canonical public production domain is `test-six-rho-qcpw39t96j.vercel.app` — health returns 200 there.

Changes:
- `apps/mobile/eas.json`: `EXPO_PUBLIC_API_URL` → public production domain (all three build profiles)
- `docs/SETUP.md`: domain references updated (incl. the RevenueCat webhook URL)
- Vercel env `BETTER_AUTH_URL` already updated to match (takes effect on this deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hyovv36uWnL2PZ6wsDaHac

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hyovv36uWnL2PZ6wsDaHac)_

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR updates the API URL from a team-scoped Vercel domain (which sits behind SSO and returns 302 redirects for API clients) to the canonical public production domain across mobile app build configurations and documentation. The change ensures API clients receive proper 200 responses instead of authentication redirects during production smoke-testing.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `apps/mobile/eas.json` |
| 2 | `docs/SETUP.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup instructions to match the latest deployment domain and webhook URL details.

* **Chores**
  * Refreshed mobile app environment settings to use the current backend endpoint across development, preview, and production builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->